### PR TITLE
chore: add connection handler via messages (async)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,9 @@ event loops, the Redis protocol and more.
 **Note**: If you're viewing this repo on GitHub, head over to
 [codecrafters.io](https://codecrafters.io) to try the challenge.
 
-# Passing the first stage
+# Timeline
 
-The entry point for your Redis implementation is in `lib/server.ex`. Study and
-uncomment the relevant code, and push your changes to pass the first stage:
-
-```sh
-git add .
-git commit -m "pass 1st stage" # any msg
-git push origin master
-```
-
-That's all!
+- PR: Improving connection handling (https://github.com/girorme/my-redis/pull/1)
 
 # Stage 2 & beyond
 

--- a/lib/handler.ex
+++ b/lib/handler.ex
@@ -1,0 +1,29 @@
+defmodule Handler do
+  @moduledoc """
+  This genserver handle incoming requests from the client as messages
+  """
+
+  use GenServer
+  require Logger
+
+  @impl true
+  def init(initial_state \\ %{socket: nil}) do
+    state = Map.put(initial_state, :client_id, :rand.uniform(9999))
+    Logger.info("[id: #{state.client_id}] Redis connection received... Waiting data")
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info({:tcp, socket, data}, %{client_id: client_id} = state) do
+    Logger.info("[id: #{client_id}] Received: #{data}")
+    :gen_tcp.send(socket, "+PONG\r\n")
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:tcp_closed, socket}, %{client_id: client_id} = state) do
+    Logger.info("[id: #{client_id}] Closing connection...")
+    :gen_tcp.send(socket, "+PONG\r\n")
+    {:noreply, state}
+  end
+end


### PR DESCRIPTION
Its possible to transfer the "handle tcp connections" using `:gen_tcp.controlling_process/2`, this way all connections can be processed as messages in async way in another process (genserver)

Ref: https://www.openmymind.net/Elegant-TCP-with-Elixir-Part-1-TCP-as-Messages/